### PR TITLE
Update documentation with the correct module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ define(['path/to/watch-once/index.js'], function(watchOnce) {
 });
 
 // global
-angular.module('app', ['watchOnce']);
+angular.module('app', ['Scope.$watchOnce']);
 
 
 


### PR DESCRIPTION
I tried using the module name specified in the documentation (`watchOnce`), got many angular errors, but then noticed in the test that it's `Scope.$watchOnce`. Just thought I'd update the documentation so no one else is confused. :)
